### PR TITLE
Bugfix/sensor data as double

### DIFF
--- a/list-sensors.cpp
+++ b/list-sensors.cpp
@@ -131,6 +131,14 @@ class Properties : public PropertiesMap
             {
                 ret = "J";
             }
+            else if ("Meters" == name)
+            {
+                ret = "m";
+            }
+            else if ("Percent" == name)
+            {
+                ret = "%";
+            }
             else
             {
                 ret = name;

--- a/list-sensors.cpp
+++ b/list-sensors.cpp
@@ -15,7 +15,7 @@
 // Bus handler singleton
 static sdbusplus::bus::bus systemBus = sdbusplus::bus::new_default();
 
-using PropertyValue = std::variant<int64_t, std::string, bool>;
+using PropertyValue = std::variant<int64_t, std::string, bool, double>;
 using PropertyName = std::string;
 using PropertiesMap = std::map<PropertyName, PropertyValue>;
 
@@ -166,6 +166,18 @@ class Properties : public PropertiesMap
         if (it == this->end())
         {
             ret = "N/A";
+        }
+        else if (std::holds_alternative<double>(it->second))
+        {
+            auto value = std::get<double>(it->second);
+            if (value < 1000)
+            {
+                snprintf(ret.data(), ret.size(), "%7.03f", value);
+            }
+            else
+            {
+                snprintf(ret.data(), ret.size(), "%7d", (int)(value));
+            }
         }
         else
         {


### PR DESCRIPTION
The value type of sensor in `phosphor-dbus-interface` was changed to
double. That made this tool unable to read the such values.

This commit brings a support for sensor's values as double.
The previous implementation is also supported.