### PR TITLE
Fix a typo in commit 27c7580cadc8a3b63d2cd380561ad70cafbed7de

### DIFF
--- a/list-sensors.cpp
+++ b/list-sensors.cpp
@@ -384,7 +384,7 @@ static int usage(char *progname, bool cli_mode)
 #ifdef WITH_REMOTE_HOST
                 "  -H, --host=[USER@]HOST   Operate on remote host (over ssh)\n"
 #endif
-                "  -c, --cli                CLI mode for obmc-yadro-cli\n",
+                "  -c, --cli                CLI mode for obmc-yadro-cli\n"
                 "  -h, --help               Show this help\n",
                 progname);
     }


### PR DESCRIPTION
There was an extra comma in aabb2cf2b4fcbc094d5695c3c56a90a4e3d94fb7 which broke building.